### PR TITLE
Fixed the docker file so importing dash works now in linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN python3.8 -m pip --no-cache-dir install -r "/talknet/requirements.txt" -f ht
 RUN python3.8 -m pip --no-cache-dir install git+https://github.com/SortAnon/NeMo.git
 RUN python3.8 -m pip uninstall -y pesq
 RUN python3.8 -m pip install pesq==0.0.2
+RUN python3.8 -m pip install werkzeug==2.0.3
 RUN touch /talknet/is_docker
 WORKDIR /talknet
 EXPOSE 8050


### PR DESCRIPTION
This pull request fixes the dockerfile so for linux users. I only had to downgrade a python library.